### PR TITLE
Add `seance` as a desktop keyword.

### DIFF
--- a/resources/com.seance.app.desktop
+++ b/resources/com.seance.app.desktop
@@ -6,6 +6,6 @@ Icon=com.seance.app
 Terminal=false
 Type=Application
 Categories=System;TerminalEmulator;
-Keywords=terminal;multiplexer;shell;console;
+Keywords=terminal;multiplexer;shell;console;seance;
 StartupNotify=true
 StartupWMClass=com.seance.app


### PR DESCRIPTION
because the name uses `é` this creates unexpected behavior when searching for the app using an app launcher without accent-insensitive searching.

(this is hitting me with [vicinae](https://www.vicinae.com/) currently)

Adding an ascii only version of the name as a keyword fixes it.

---
current behavior, doesn't show up with `seance`
<img width="795" height="497" alt="image" src="https://github.com/user-attachments/assets/be290800-09c8-4a0f-99d6-d0660eb71711" />
 
does show up if I use a keyword: 
<img width="795" height="497" alt="image" src="https://github.com/user-attachments/assets/8295f730-92bb-4c92-944c-eb877ad570f3" />


