### PR TITLE
fix: respect xkb keysym remaps for editing keys

### DIFF
--- a/src/pane.zig
+++ b/src/pane.zig
@@ -834,6 +834,32 @@ fn initSurface(pane: *Pane, width: u32, height: u32) void {
 
 // ── Key event handling ──────────────────────────────────────────────
 
+// Map a keyval to the canonical Linux evdev+8 keycode that natively produces
+// it. Used to repair events where an xkb remap (e.g. Caps Lock to BackSpace)
+// changes the keyval but leaves the original physical keycode. libghostty's
+// key handling is keycode-driven, so the unremapped keycode would otherwise
+// be interpreted as the original physical key.
+fn canonicalKeycode(keyval: c.guint, keycode: c.guint) c.guint {
+    return switch (keyval) {
+        c.GDK_KEY_BackSpace => 22,
+        c.GDK_KEY_Tab, c.GDK_KEY_ISO_Left_Tab => 23,
+        c.GDK_KEY_Return => 36,
+        c.GDK_KEY_KP_Enter => 104,
+        c.GDK_KEY_Escape => 9,
+        c.GDK_KEY_Delete => 119,
+        c.GDK_KEY_Insert => 118,
+        c.GDK_KEY_Home => 110,
+        c.GDK_KEY_End => 115,
+        c.GDK_KEY_Page_Up => 112,
+        c.GDK_KEY_Page_Down => 117,
+        c.GDK_KEY_Left => 113,
+        c.GDK_KEY_Right => 114,
+        c.GDK_KEY_Up => 111,
+        c.GDK_KEY_Down => 116,
+        else => keycode,
+    };
+}
+
 fn translateMods(state: c.GdkModifierType) c.ghostty_input_mods_e {
     var mods: c_uint = c.GHOSTTY_MODS_NONE;
     const s: c_uint = @bitCast(state);
@@ -961,11 +987,18 @@ fn handleKeyEvent(
     // Get unshifted codepoint
     const unshifted = c.gdk_keyval_to_unicode(c.gdk_keyval_to_lower(keyval));
 
+    // Repair xkb keysym remaps (e.g. Caps Lock to BackSpace) by overriding
+    // the keycode to one that natively produces the same keyval. When the
+    // keycode changes, also strip the Lock-derived CAPS modifier so the
+    // remap source key doesn't leak Caps state into the synthesized event.
+    const effective_keycode = canonicalKeycode(keyval, keycode);
+    if (effective_keycode != keycode) mods &= ~@as(c_uint, c.GHOSTTY_MODS_CAPS);
+
     const key_ev = c.ghostty_input_key_s{
         .action = if (is_release) c.GHOSTTY_ACTION_RELEASE else c.GHOSTTY_ACTION_PRESS,
         .mods = @intCast(mods),
         .consumed_mods = @intCast(consumed),
-        .keycode = keycode,
+        .keycode = effective_keycode,
         .text = text_ptr,
         .unshifted_codepoint = @intCast(if (unshifted > 0) unshifted else 0),
         .composing = pane.im_composing,


### PR DESCRIPTION
## Why I'm filing this

I use the Colemak keyboard layout and have Caps Lock remapped to Backspace at the xkb level — this is a very common ergonomic setup (Caps Lock is unused real estate, Backspace gets used constantly, the remap puts it under a home-row finger). Every other app on my system honours the remap. In Seance the remapped key does nothing, which makes the terminal effectively unusable for me without reaching across the keyboard for the real Backspace key.

This patch makes Seance honour the remap.

## Summary

xkb-level keysym remaps (e.g. KDE's *Caps Lock behaves as Backspace*) are silently dropped inside Seance. The remapped key sends nothing to the terminal even though `wev` confirms the Wayland compositor delivers the remapped keysym.

## Root cause

GDK delivers a `(keyval, hardware_keycode)` pair where the keyval reflects the xkb remap but the hardware keycode still identifies the original physical key. `handleKeyEvent` in `src/pane.zig` forwards the raw keycode to `ghostty_surface_key`. libghostty's input handling is keycode-driven (`ghostty/src/apprt/embedded.zig` looks up the physical key in `input/keycodes.zig` by `entry.native == keycode`), so it sees the original physical key and ignores the remap.

For Caps Lock to Backspace on Linux: GDK reports `keyval = BackSpace`, `keycode = 66` (Caps physical). libghostty sees keycode 66, identifies it as Caps Lock, and treats the event as a modifier press rather than producing Backspace input.

## Fix

`canonicalKeycode(keyval, keycode)` returns the Linux evdev+8 keycode that natively produces the given keyval for a small set of named editing/navigation keys. `handleKeyEvent` uses the canonical keycode when it differs and strips `GHOSTTY_MODS_CAPS` in that case so the remap source's Lock state doesn't leak into the event.

## Repro

1. KDE System Settings → Keyboard → Layouts → Advanced → "Caps Lock behaviour" → *Make Caps Lock an additional Backspace* (or any xkb option that remaps Caps to BackSpace).
2. In Seance: pressing Caps Lock does nothing; real Backspace works.
3. `wev` confirms `sym: BackSpace, utf8: '\b'` for the Caps press.
4. With this patch: Caps acts as Backspace inside Seance.

## Notes / questions for review

- **Scope.** Limited to the named keys most likely to be remap targets (BackSpace, Tab, Return, KP_Enter, Escape, Delete, Insert, Home, End, PgUp/PgDn, arrows). I deliberately did not expand beyond what was needed to fix the reported case; happy to add F-keys etc. if you'd prefer.
- **Hardcoded keycodes.** `gdk_display_map_keyval` would query GDK for keycodes that produce a given keyval and avoid the hardcoded table. I went with the table because it allocates nothing on a hot input path, the editing-key set is small and stable on Linux, and Seance is already Linux-only per `build.zig`. Open to switching if you'd prefer.
- **Alternative location.** The same issue could be fixed inside libghostty (use keysym, not keycode, for non-modifier keys). The Seance-side fix is pragmatic; let me know if you'd rather see this upstream in your ghostty fork.
- **Tested manually** with a release build under KDE Plasma 6 / Wayland on Bazzite. No automated tests touched.

## Test plan

- [x] `zig build` succeeds
- [x] Caps Lock → Backspace works in patched Seance under KDE Wayland (Colemak layout)
- [x] Real Backspace still works
- [x] No regressions observed in regular typing, arrow keys, or modifier-letter shortcuts