### PR TITLE
Add Debian 12 (GTK 4.8 / libadwaita 1.2) build compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,27 @@ zig build
 
 The binary is at `zig-out/bin/seance`.
 
+### Debian 12 (bookworm)
+
+Debian 12 ships GTK 4.8 and libadwaita 1.2, which are older than the versions
+above. This tree carries a compatibility layer (see
+[`packaging/debian12/`](packaging/debian12/)) that lets séance build against
+those older libraries, so on Debian 12 you can build straight from source — on
+**arm64** and amd64 — with one command:
+
+```bash
+git clone --recursive https://github.com/no1msd/seance.git
+cd seance
+./packaging/debian12/install.sh   # installs deps, fetches Zig, builds, installs to ~/.local/bin
+```
+
+> **VM / no GPU?** Ghostty's panes need an OpenGL context. Without accelerated
+> GL (e.g. `virtio-gpu` with no virglrenderer), force Mesa's software renderer:
+> `LIBGL_ALWAYS_SOFTWARE=1 seance`.
+
+See [`packaging/debian12/README.md`](packaging/debian12/README.md) for the full
+list of API substitutions and dependencies.
+
 ## Contributing
 
 Bug reports, feature requests, and pull requests are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for how to file issues, build locally, and add support for new agents. Questions and show-and-tell go in [Discussions](https://github.com/no1msd/seance/discussions). Security issues should be reported privately, see [SECURITY.md](SECURITY.md).

--- a/packaging/debian12/README.md
+++ b/packaging/debian12/README.md
@@ -1,0 +1,69 @@
+# Séance on Debian 12 (bookworm)
+
+Séance targets recent GNOME libraries (GTK 4.12+, libadwaita 1.4/1.5+). Debian
+12 "bookworm" ships **GTK 4.8.3** and **libadwaita 1.2.2**, which predate
+several APIs séance uses. This directory documents a compatibility layer that
+lets séance build and run on those older libraries — useful for Debian 12 and
+other long-term-support distributions that haven't moved to libadwaita 1.4+ yet.
+
+Verified on Debian 12 **arm64** (aarch64) and applicable to amd64.
+
+## Quick start
+
+```bash
+git clone --recursive https://github.com/no1msd/seance.git
+cd seance
+./packaging/debian12/install.sh
+```
+
+The script installs the system build dependencies, fetches a pinned Zig
+toolchain (Zig is not packaged in Debian 12), builds with `zig build
+-Doptimize=ReleaseFast`, and installs the binary to `~/.local/bin/seance`.
+
+## What the compatibility patch changes
+
+Each substitution uses an API that already exists in GTK 4.8 / libadwaita 1.2
+and is behaviourally equivalent to the newer call:
+
+| Upstream API (min version) | Debian 12 replacement |
+| --- | --- |
+| `gtk_gl_area_set_allowed_apis` (GTK 4.12) | `gtk_gl_area_set_use_es(area, FALSE)` — keeps the desktop-GL request |
+| `gtk_css_provider_load_from_string` (GTK 4.12) | `gtk_css_provider_load_from_data(p, data, -1)` |
+| `gtk_search_entry_set_placeholder_text` (GTK 4.10) | placeholder set on the entry's `GtkText` editable delegate |
+| `GtkFontDialogButton` (GTK 4.10) | `GtkFontButton` (uses the `GtkFontChooser` `font-desc` property) |
+| `AdwAlertDialog` (libadwaita 1.5) | `AdwMessageDialog` (libadwaita 1.2) |
+| `AdwDialog` (libadwaita 1.5) | `AdwWindow` + `GtkWindow` (modal, transient-for, present) |
+| `AdwToolbarView` (libadwaita 1.4) | a vertical `GtkBox` (header on top, content below) |
+| `AdwBanner` (libadwaita 1.4) | a `GtkRevealer` wrapping a label + optional action button |
+| `AdwSpinRow` (libadwaita 1.4) | `AdwActionRow` + `GtkSpinButton` suffix |
+| `AdwSwitchRow` (libadwaita 1.4) | `AdwActionRow` + `GtkSwitch` suffix |
+| `adw_combo_row_set_enable_search` (libadwaita 1.4) | omitted (search box is optional) |
+
+All changes are source-level only; no new runtime dependencies are introduced.
+
+## Dependencies
+
+Build: `git pkg-config gettext blueprint-compiler libgtk-4-dev libadwaita-1-dev
+libgl1-mesa-dev libegl1-mesa-dev libnotify-dev libcanberra-dev libonig-dev`,
+plus Zig 0.15.2 (downloaded by the install script).
+
+## GPU / OpenGL note
+
+Ghostty's terminal panes render through an OpenGL context (`GtkGLArea`). On bare
+metal with working GPU drivers this is automatic. In a VM **without** accelerated
+GL — e.g. `virtio-gpu` with no `virglrenderer` on the host — desktop-GL context
+creation fails with `Unable to create a GL context`. Force Mesa's software
+renderer in that case:
+
+```bash
+LIBGL_ALWAYS_SOFTWARE=1 seance
+```
+
+## Verified
+
+- Builds cleanly from source (libghostty + séance) on Debian 12 arm64.
+- Launches; `seance ctl ping` → `pong`; `seance ctl tree` / `identify` work.
+- OpenGL context succeeds (software renderer in the virtio-gpu test VM).
+
+Interactive terminal rendering should be confirmed on a real desktop session —
+the panes only initialise once the compositor maps and paints the window.

--- a/packaging/debian12/README.md
+++ b/packaging/debian12/README.md
@@ -59,11 +59,16 @@ renderer in that case:
 LIBGL_ALWAYS_SOFTWARE=1 seance
 ```
 
-## Verified
+## Verified (Debian 12 arm64)
 
-- Builds cleanly from source (libghostty + séance) on Debian 12 arm64.
+- Builds cleanly from source (libghostty + séance).
 - Launches; `seance ctl ping` → `pong`; `seance ctl tree` / `identify` work.
-- OpenGL context succeeds (software renderer in the virtio-gpu test VM).
+- OpenGL context succeeds (software renderer on the virtio-gpu test VM).
+- **Interactive pane rendering confirmed.** Against a painting display, the
+  `GtkGLArea` renders and ghostty spawns the pane's shell: a live `sh` child
+  process and pty appear, the pane title tracks the shell prompt
+  (`debian@debian: ~`), and the header bar, sidebar, and terminal all draw
+  correctly.
 
-Interactive terminal rendering should be confirmed on a real desktop session —
-the panes only initialise once the compositor maps and paints the window.
+Note: panes only initialise once the compositor actually paints the window, so
+a purely headless session that never composites a frame won't start them.

--- a/packaging/debian12/README.md
+++ b/packaging/debian12/README.md
@@ -72,3 +72,29 @@ LIBGL_ALWAYS_SOFTWARE=1 seance
 
 Note: panes only initialise once the compositor actually paints the window, so
 a purely headless session that never composites a frame won't start them.
+
+## Known warnings (benign)
+
+At startup you may see this logged once:
+
+```
+Adwaita-CRITICAL **: adw_tab_view_close_page: assertion 'page_belongs_to_this_view (self, page)' failed
+```
+
+It is **non-fatal and cosmetic** — the terminal pane spawns and renders normally.
+
+- **Source:** séance's stacked-mode layout. Each column defaults to stacked mode
+  on creation (`workspace.zig`), so `PaneGroup.enterStackedMode` immediately moves
+  the pane out of its `AdwTabView` by unparenting the widget directly (intentional —
+  it avoids an unrealize→realize cycle that would destroy the GLArea's GL context),
+  then closes the now child-less pages.
+- **Why it surfaces here:** on libadwaita 1.2, `adw_tab_view_close_page` rejects a
+  page whose child was unparented behind the view's back. libadwaita logs the
+  assertion and returns; the cleanup loop's guard then exits cleanly. Upstream
+  targets libadwaita 1.4+, where this path doesn't trip the assertion.
+- **Not introduced by this compatibility patch** — the stacked-mode code is
+  unchanged; only the older library is stricter.
+
+Left as-is intentionally: the safe-looking fixes would either reintroduce the
+GL-context loss the stacked-mode code is engineered to avoid, or the moved-widget
+disposal issue its comments describe.

--- a/packaging/debian12/install.sh
+++ b/packaging/debian12/install.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# Séance — build & install on Debian 12 (bookworm).
+#
+# Debian 12 ships GTK 4.8 and libadwaita 1.2, which are older than séance's
+# default target (GTK 4.12+, libadwaita 1.4/1.5+). This tree carries a
+# compatibility patch that lets it build against those older libraries, so on
+# Debian 12 you can build straight from source with this script.
+#
+# Works on arm64 (aarch64) and amd64 (x86_64). Run from the repository root:
+#
+#     ./packaging/debian12/install.sh
+#
+set -euo pipefail
+
+ZIG_VERSION="0.15.2"
+PREFIX="${PREFIX:-$HOME/.local}"
+
+log() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+die() { printf '\033[1;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+
+[ -f build.zig ] || die "run this from the séance repository root (build.zig not found)"
+
+# ── 1. System build dependencies ───────────────────────────────────────────
+log "Installing build dependencies (sudo apt)…"
+sudo apt-get update -qq
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    git pkg-config gettext blueprint-compiler \
+    libgtk-4-dev libadwaita-1-dev \
+    libgl1-mesa-dev libegl1-mesa-dev \
+    libnotify-dev libcanberra-dev libonig-dev
+
+# ── 2. Fetch a pinned Zig toolchain (not packaged in Debian 12) ─────────────
+case "$(uname -m)" in
+    aarch64|arm64) ZIG_ARCH="aarch64" ;;
+    x86_64|amd64)  ZIG_ARCH="x86_64"  ;;
+    *) die "unsupported architecture: $(uname -m)" ;;
+esac
+
+ZIG_DIR="$(pwd)/.zig-toolchain"
+ZIG="$ZIG_DIR/zig"
+if [ ! -x "$ZIG" ] || ! "$ZIG" version 2>/dev/null | grep -q "^${ZIG_VERSION}$"; then
+    TARBALL="zig-${ZIG_ARCH}-linux-${ZIG_VERSION}.tar.xz"
+    URL="https://ziglang.org/download/${ZIG_VERSION}/${TARBALL}"
+    log "Downloading Zig ${ZIG_VERSION} for ${ZIG_ARCH}…"
+    rm -rf "$ZIG_DIR"; mkdir -p "$ZIG_DIR"
+    curl -fSL "$URL" -o "/tmp/${TARBALL}"
+    tar -xf "/tmp/${TARBALL}" -C "$ZIG_DIR" --strip-components=1
+    rm -f "/tmp/${TARBALL}"
+fi
+log "Using $("$ZIG" version) at $ZIG"
+
+# ── 3. Make sure the ghostty submodule is present ───────────────────────────
+if [ ! -e ghostty/build.zig ]; then
+    log "Fetching ghostty submodule…"
+    git submodule update --init --recursive
+fi
+
+# ── 4. Build ────────────────────────────────────────────────────────────────
+log "Building séance (ReleaseFast)… this compiles libghostty and takes a while."
+"$ZIG" build -Doptimize=ReleaseFast
+
+# ── 5. Install ────────────────────────────────────────────────────────────────
+install -Dm755 zig-out/bin/seance "$PREFIX/bin/seance"
+log "Installed séance to $PREFIX/bin/seance"
+
+case ":$PATH:" in
+    *":$PREFIX/bin:"*) : ;;
+    *) printf '\033[1;33mnote:\033[0m add %s to your PATH (e.g. in ~/.bashrc): export PATH="%s:$PATH"\n' "$PREFIX/bin" "$PREFIX/bin" ;;
+esac
+
+cat <<'EOF'
+
+Done. Launch with:  seance
+Control a running instance with:  seance ctl <command>   (try: seance ctl tree)
+
+GPU note: ghostty's terminal panes need an OpenGL context. On bare metal with
+working GPU drivers this is automatic. In a VM without accelerated GL (e.g.
+virtio-gpu with no virglrenderer), force Mesa's software renderer:
+
+    LIBGL_ALWAYS_SOFTWARE=1 seance
+
+EOF

--- a/src/command_palette.zig
+++ b/src/command_palette.zig
@@ -313,7 +313,9 @@ pub const CommandPalette = struct {
         // Search entry (commands/switcher mode)
         const entry = c.gtk_search_entry_new();
         c.gtk_widget_add_css_class(entry, "command-palette-entry");
-        c.gtk_search_entry_set_placeholder_text(@ptrCast(entry), "Type a command");
+        // GTK 4.8 compat: set_placeholder_text on GtkSearchEntry is 4.10+; set it
+        // on the internal GtkText editable delegate instead.
+        c.gtk_text_set_placeholder_text(@ptrCast(@alignCast(c.gtk_editable_get_delegate(@ptrCast(entry)))), "Type a command");
         c.gtk_box_append(@ptrCast(palette_box), entry);
 
         // Rename entry (hidden by default)
@@ -466,7 +468,7 @@ pub const CommandPalette = struct {
         self.showSearchUI();
         c.gtk_widget_set_visible(self.overlay, 1);
         c.gtk_editable_set_text(@ptrCast(self.entry), "");
-        c.gtk_search_entry_set_placeholder_text(@ptrCast(self.entry), "Search workspaces...");
+        c.gtk_text_set_placeholder_text(@ptrCast(@alignCast(c.gtk_editable_get_delegate(@ptrCast(self.entry)))), "Search workspaces...");
         self.updateResults("");
         _ = c.gtk_widget_grab_focus(self.entry);
     }
@@ -505,7 +507,7 @@ pub const CommandPalette = struct {
                 self.mode = .switcher;
                 self.showSearchUI();
                 c.gtk_editable_set_text(@ptrCast(self.entry), "");
-                c.gtk_search_entry_set_placeholder_text(@ptrCast(self.entry), "Search workspaces...");
+                c.gtk_text_set_placeholder_text(@ptrCast(@alignCast(c.gtk_editable_get_delegate(@ptrCast(self.entry)))), "Search workspaces...");
                 self.updateResults("");
                 _ = c.gtk_widget_grab_focus(self.entry);
             }
@@ -1330,9 +1332,9 @@ fn onSearchChanged(_: *c.GtkSearchEntry, user_data: c.gpointer) callconv(.c) voi
         palette.mode = new_mode;
         // Update placeholder
         if (new_mode == .commands) {
-            c.gtk_search_entry_set_placeholder_text(@ptrCast(palette.entry), "Type a command");
+            c.gtk_text_set_placeholder_text(@ptrCast(@alignCast(c.gtk_editable_get_delegate(@ptrCast(palette.entry)))), "Type a command");
         } else {
-            c.gtk_search_entry_set_placeholder_text(@ptrCast(palette.entry), "Search workspaces...");
+            c.gtk_text_set_placeholder_text(@ptrCast(@alignCast(c.gtk_editable_get_delegate(@ptrCast(palette.entry)))), "Search workspaces...");
         }
     }
 

--- a/src/pane.zig
+++ b/src/pane.zig
@@ -83,7 +83,9 @@ pub const Pane = struct {
         c.gtk_gl_area_set_auto_render(gl_area, 0);
         // Ghostty requires desktop OpenGL (not OpenGL ES) — match ghostty's
         // own GTK apprt which uses allowed-apis: gl in the surface blueprint.
-        c.gtk_gl_area_set_allowed_apis(gl_area, c.GDK_GL_API_GL);
+        // GTK 4.8 compat: set_allowed_apis (4.12+) is unavailable; set_use_es(false)
+        // is the older equivalent for forcing desktop OpenGL (not GLES).
+        c.gtk_gl_area_set_use_es(gl_area, 0);
         c.gtk_widget_set_hexpand(gl_area_widget, 1);
         c.gtk_widget_set_vexpand(gl_area_widget, 1);
         c.gtk_widget_set_focusable(gl_area_widget, 1);

--- a/src/pane_group.zig
+++ b/src/pane_group.zig
@@ -695,13 +695,13 @@ fn onCtxRename(_: *c.GSimpleAction, _: ?*c.GVariant, data: c.gpointer) callconv(
 
     const root = c.gtk_widget_get_root(asWidget(self.tab_view)) orelse return;
 
-    const dialog = c.adw_alert_dialog_new("Rename Tab", null);
-    c.adw_alert_dialog_add_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "cancel", "Cancel");
-    c.adw_alert_dialog_add_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "clear", "Clear");
-    c.adw_alert_dialog_add_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "rename", "Rename");
-    c.adw_alert_dialog_set_response_appearance(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "rename", c.ADW_RESPONSE_SUGGESTED);
-    c.adw_alert_dialog_set_default_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "rename");
-    c.adw_alert_dialog_set_close_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "cancel");
+    const dialog = c.adw_message_dialog_new(@ptrCast(@alignCast(root)), "Rename Tab", null);
+    c.adw_message_dialog_add_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "cancel", "Cancel");
+    c.adw_message_dialog_add_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "clear", "Clear");
+    c.adw_message_dialog_add_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "rename", "Rename");
+    c.adw_message_dialog_set_response_appearance(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "rename", c.ADW_RESPONSE_SUGGESTED);
+    c.adw_message_dialog_set_default_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "rename");
+    c.adw_message_dialog_set_close_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "cancel");
 
     const entry = c.gtk_entry_new();
     c.gtk_entry_set_activates_default(@ptrCast(entry), 1);
@@ -711,13 +711,13 @@ fn onCtxRename(_: *c.GSimpleAction, _: ?*c.GVariant, data: c.gpointer) callconv(
     @memcpy(title_z[0..tlen], display_title[0..tlen]);
     title_z[tlen] = 0;
     c.gtk_editable_set_text(@ptrCast(entry), &title_z);
-    c.adw_alert_dialog_set_extra_child(@as(*c.AdwAlertDialog, @ptrCast(dialog)), entry);
+    c.adw_message_dialog_set_extra_child(@as(*c.AdwMessageDialog, @ptrCast(dialog)), entry);
 
     const ctx = self.alloc.create(RenameCtx) catch return;
     ctx.* = .{ .group = self, .pane_id = pane.id, .entry = @ptrCast(entry) };
 
     _ = c.g_signal_connect_data(@as(c.gpointer, @ptrCast(dialog)), "response", @as(c.GCallback, @ptrCast(&onCtxRenameResponse)), @ptrCast(ctx), null, 0);
-    c.adw_dialog_present(@as(*c.AdwDialog, @ptrCast(dialog)), @ptrCast(@alignCast(root)));
+    c.gtk_window_present(@ptrCast(@alignCast(dialog)));
 
     _ = c.gtk_widget_grab_focus(entry);
     c.gtk_editable_select_region(@ptrCast(entry), 0, -1);
@@ -729,7 +729,7 @@ const RenameCtx = struct {
     entry: *c.GtkEditable,
 };
 
-fn onCtxRenameResponse(_: *c.AdwAlertDialog, response: [*:0]const u8, data: c.gpointer) callconv(.c) void {
+fn onCtxRenameResponse(_: *c.AdwMessageDialog, response: [*:0]const u8, data: c.gpointer) callconv(.c) void {
     const ctx: *RenameCtx = @ptrCast(@alignCast(data));
     const resp = std.mem.sliceTo(response, 0);
 
@@ -813,12 +813,12 @@ fn showCloseConfirmDialog(group: *PaneGroup, page: *c.AdwTabPage, right_only: bo
     var msg_buf: [128:0]u8 = [_:0]u8{0} ** 128;
     _ = std.fmt.bufPrint(&msg_buf, "This will close {d} tab{s} and their terminal sessions.", .{ count, if (count != 1) "s" else "" }) catch {};
 
-    const dialog = c.adw_alert_dialog_new(title, &msg_buf);
-    c.adw_alert_dialog_add_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "cancel", "Cancel");
-    c.adw_alert_dialog_add_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "close", "Close");
-    c.adw_alert_dialog_set_response_appearance(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "close", c.ADW_RESPONSE_DESTRUCTIVE);
-    c.adw_alert_dialog_set_default_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "cancel");
-    c.adw_alert_dialog_set_close_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "cancel");
+    const dialog = c.adw_message_dialog_new(@ptrCast(@alignCast(root)), title, &msg_buf);
+    c.adw_message_dialog_add_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "cancel", "Cancel");
+    c.adw_message_dialog_add_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "close", "Close");
+    c.adw_message_dialog_set_response_appearance(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "close", c.ADW_RESPONSE_DESTRUCTIVE);
+    c.adw_message_dialog_set_default_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "cancel");
+    c.adw_message_dialog_set_close_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "cancel");
 
     const ctx = group.alloc.create(CloseDialogCtx) catch return;
     ctx.* = .{
@@ -829,10 +829,10 @@ fn showCloseConfirmDialog(group: *PaneGroup, page: *c.AdwTabPage, right_only: bo
     };
 
     _ = c.g_signal_connect_data(@as(c.gpointer, @ptrCast(dialog)), "response", @as(c.GCallback, @ptrCast(&onCloseDialogResponse)), @ptrCast(ctx), null, 0);
-    c.adw_dialog_present(@as(*c.AdwDialog, @ptrCast(dialog)), @ptrCast(@alignCast(root)));
+    c.gtk_window_present(@ptrCast(@alignCast(dialog)));
 }
 
-fn onCloseDialogResponse(_: *c.AdwAlertDialog, response: [*:0]const u8, data: c.gpointer) callconv(.c) void {
+fn onCloseDialogResponse(_: *c.AdwMessageDialog, response: [*:0]const u8, data: c.gpointer) callconv(.c) void {
     const ctx: *CloseDialogCtx = @ptrCast(@alignCast(data));
     if (std.mem.eql(u8, std.mem.sliceTo(response, 0), "close")) {
         if (ctx.right_only) {

--- a/src/settings.zig
+++ b/src/settings.zig
@@ -88,18 +88,20 @@ fn createWindow() void {
 
     const cfg = config_mod.get();
 
-    const window = c.adw_dialog_new();
-    c.adw_dialog_set_title(@as(*c.AdwDialog, @ptrCast(window)), "Settings");
-    c.adw_dialog_set_content_width(@as(*c.AdwDialog, @ptrCast(window)), 800);
-    c.adw_dialog_set_content_height(@as(*c.AdwDialog, @ptrCast(window)), 680);
+    // libadwaita 1.2 compat: AdwDialog (1.5) -> AdwWindow (a GtkWindow).
+    const window = c.adw_window_new();
+    c.gtk_window_set_title(@as(*c.GtkWindow, @ptrCast(window)), "Settings");
+    c.gtk_window_set_default_size(@as(*c.GtkWindow, @ptrCast(window)), 800, 680);
+    c.gtk_window_set_transient_for(@as(*c.GtkWindow, @ptrCast(window)), @ptrCast(@alignCast(parent.?)));
+    c.gtk_window_set_modal(@as(*c.GtkWindow, @ptrCast(window)), 1);
 
     // Header bar
     const header = c.adw_header_bar_new();
 
     // Toolbar view (flat top bar — gains separator on scroll)
-    const toolbar_view = c.adw_toolbar_view_new();
-    c.adw_toolbar_view_add_top_bar(@as(*c.AdwToolbarView, @ptrCast(toolbar_view)), @ptrCast(header));
-    c.adw_toolbar_view_set_top_bar_style(@as(*c.AdwToolbarView, @ptrCast(toolbar_view)), c.ADW_TOOLBAR_FLAT);
+    // libadwaita 1.2 compat: AdwToolbarView (1.4) -> vertical GtkBox.
+    const toolbar_view = c.gtk_box_new(c.GTK_ORIENTATION_VERTICAL, 0);
+    c.gtk_box_append(@ptrCast(toolbar_view), @ptrCast(header));
 
     // Preferences page (handles scrolling and group spacing)
     const page = c.adw_preferences_page_new();
@@ -115,8 +117,9 @@ fn createWindow() void {
     buildResetSection(page);
     updating = false;
 
-    c.adw_toolbar_view_set_content(@as(*c.AdwToolbarView, @ptrCast(toolbar_view)), page);
-    c.adw_dialog_set_child(@as(*c.AdwDialog, @ptrCast(window)), @ptrCast(toolbar_view));
+    c.gtk_widget_set_vexpand(page, 1);
+    c.gtk_box_append(@ptrCast(toolbar_view), page);
+    c.adw_window_set_content(@as(*c.AdwWindow, @ptrCast(window)), @ptrCast(toolbar_view));
 
     // Key controller for shortcut recording — attached to the dialog itself
     // with CAPTURE phase so we intercept keypresses before internal AdwDialog widgets.
@@ -134,10 +137,11 @@ fn createWindow() void {
     key_ctrl_ref = @as(*c.GtkEventController, @ptrCast(key_ctrl));
     dialog_widget_ref = @as(*c.GtkWidget, @ptrCast(window));
 
-    // Closed signal
+    // Destroy signal (AdwWindow has no AdwDialog "closed"); fires on user close
+    // too, since GtkWindow:hide-on-close defaults to false.
     _ = c.g_signal_connect_data(
         @as(c.gpointer, @ptrCast(window)),
-        "closed",
+        "destroy",
         @as(c.GCallback, @ptrCast(&onDialogClosed)),
         null,
         null,
@@ -145,7 +149,7 @@ fn createWindow() void {
     );
 
     win = @as(*c.GtkWidget, @ptrCast(window));
-    c.adw_dialog_present(@as(*c.AdwDialog, @ptrCast(window)), parent.?);
+    c.gtk_window_present(@as(*c.GtkWindow, @ptrCast(window)));
 }
 
 // ---------------------------------------------------------------------------
@@ -157,7 +161,7 @@ fn buildAppearanceSection(page: *c.GtkWidget, cfg: *const config_mod.Config) voi
     {
         const row = c.adw_combo_row_new();
         c.adw_preferences_row_set_title(@as(*c.AdwPreferencesRow, @ptrCast(row)), "Theme");
-        c.adw_combo_row_set_enable_search(@as(*c.AdwComboRow, @ptrCast(row)), 1);
+        // adw_combo_row_set_enable_search requires libadwaita 1.4; omitted on 1.2.
         const expression = c.gtk_property_expression_new(c.gtk_string_object_get_type(), null, "string");
         c.adw_combo_row_set_expression(@as(*c.AdwComboRow, @ptrCast(row)), expression);
 
@@ -172,14 +176,16 @@ fn buildAppearanceSection(page: *c.GtkWidget, cfg: *const config_mod.Config) voi
         const row = c.adw_action_row_new();
         c.adw_preferences_row_set_title(@as(*c.AdwPreferencesRow, @ptrCast(row)), "Font Family");
         c.adw_action_row_set_subtitle(@as(*c.AdwActionRow, @ptrCast(row)), "Terminal font face. Must be a monospace font.");
-        const btn = c.gtk_font_dialog_button_new(c.gtk_font_dialog_new());
+        // GTK 4.8 compat: GtkFontDialogButton is 4.10+; GtkFontButton (implements
+        // GtkFontChooser, has the "font-desc" property) is the older equivalent.
+        const btn = c.gtk_font_button_new();
         if (cfg.font_family_len > 0) {
             var desc_buf: [192]u8 = undefined;
             const desc_str = std.fmt.bufPrintZ(&desc_buf, "{s} {d}", .{ cfg.font_family[0..cfg.font_family_len], @as(u32, @intFromFloat(cfg.font_size orelse 11.0)) }) catch null;
             if (desc_str) |ds| {
                 const desc = c.pango_font_description_from_string(ds.ptr);
                 if (desc != null) {
-                    c.gtk_font_dialog_button_set_font_desc(@as(*c.GtkFontDialogButton, @ptrCast(btn)), desc);
+                    c.gtk_font_chooser_set_font_desc(@as(*c.GtkFontChooser, @ptrCast(btn)), desc);
                     c.pango_font_description_free(desc);
                 }
             }
@@ -593,13 +599,19 @@ fn newGroup(title: ?[*:0]const u8) *c.GtkWidget {
 }
 
 fn addSwitchRow(group: *c.GtkWidget, title: [*:0]const u8, subtitle: [*:0]const u8, active: bool) *c.GtkWidget {
-    const row = c.adw_switch_row_new();
+    // libadwaita 1.2 compat: AdwSwitchRow (1.4) -> AdwActionRow + GtkSwitch suffix.
+    // We return the GtkSwitch so callers store it for value get/set and identity.
+    const row = c.adw_action_row_new();
     c.adw_preferences_row_set_title(@as(*c.AdwPreferencesRow, @ptrCast(row)), title);
     c.adw_action_row_set_subtitle(@as(*c.AdwActionRow, @ptrCast(row)), subtitle);
-    c.adw_switch_row_set_active(@as(*c.AdwSwitchRow, @ptrCast(row)), if (active) 1 else 0);
+    const sw = c.gtk_switch_new();
+    c.gtk_switch_set_active(@as(*c.GtkSwitch, @ptrCast(sw)), if (active) 1 else 0);
+    c.gtk_widget_set_valign(sw, c.GTK_ALIGN_CENTER);
+    c.adw_action_row_add_suffix(@as(*c.AdwActionRow, @ptrCast(row)), sw);
+    c.adw_action_row_set_activatable_widget(@as(*c.AdwActionRow, @ptrCast(row)), sw);
     c.adw_preferences_group_add(@as(*c.AdwPreferencesGroup, @ptrCast(group)), @as(*c.GtkWidget, @ptrCast(row)));
-    _ = c.g_signal_connect_data(@as(c.gpointer, @ptrCast(row)), "notify::active", @as(c.GCallback, @ptrCast(&onSwitchChanged)), null, null, 0);
-    return @as(*c.GtkWidget, @ptrCast(row));
+    _ = c.g_signal_connect_data(@as(c.gpointer, @ptrCast(sw)), "notify::active", @as(c.GCallback, @ptrCast(&onSwitchChanged)), null, null, 0);
+    return @as(*c.GtkWidget, @ptrCast(sw));
 }
 
 fn addComboRow(group: *c.GtkWidget, title: [*:0]const u8, items: []const [*:0]const u8, selected: u32) *c.GtkWidget {
@@ -635,13 +647,19 @@ fn addEntryRow(group: *c.GtkWidget, title: [*:0]const u8, placeholder: [*:0]cons
 }
 
 fn addSpinRow(group: *c.GtkWidget, title: [*:0]const u8, subtitle: [*:0]const u8, min: f64, max: f64, step: f64, value: f64) *c.GtkWidget {
-    const row = c.adw_spin_row_new_with_range(min, max, step);
+    // libadwaita 1.2 compat: AdwSpinRow (1.4) -> AdwActionRow + GtkSpinButton suffix.
+    // We return the GtkSpinButton so callers store it for value get/set and identity.
+    const row = c.adw_action_row_new();
     c.adw_preferences_row_set_title(@as(*c.AdwPreferencesRow, @ptrCast(row)), title);
     c.adw_action_row_set_subtitle(@as(*c.AdwActionRow, @ptrCast(row)), subtitle);
-    c.adw_spin_row_set_value(@as(*c.AdwSpinRow, @ptrCast(row)), value);
+    const spin = c.gtk_spin_button_new_with_range(min, max, step);
+    c.gtk_spin_button_set_value(@as(*c.GtkSpinButton, @ptrCast(spin)), value);
+    c.gtk_widget_set_valign(spin, c.GTK_ALIGN_CENTER);
+    c.adw_action_row_add_suffix(@as(*c.AdwActionRow, @ptrCast(row)), spin);
+    c.adw_action_row_set_activatable_widget(@as(*c.AdwActionRow, @ptrCast(row)), spin);
     c.adw_preferences_group_add(@as(*c.AdwPreferencesGroup, @ptrCast(group)), @as(*c.GtkWidget, @ptrCast(row)));
-    _ = c.g_signal_connect_data(@as(c.gpointer, @ptrCast(row)), "notify::value", @as(c.GCallback, @ptrCast(&onSpinChanged)), null, null, 0);
-    return @as(*c.GtkWidget, @ptrCast(row));
+    _ = c.g_signal_connect_data(@as(c.gpointer, @ptrCast(spin)), "notify::value", @as(c.GCallback, @ptrCast(&onSpinChanged)), null, null, 0);
+    return @as(*c.GtkWidget, @ptrCast(spin));
 }
 
 fn addToPage(page: *c.GtkWidget, group: *c.GtkWidget) void {
@@ -655,7 +673,7 @@ fn addToPage(page: *c.GtkWidget, group: *c.GtkWidget) void {
 fn onSwitchChanged(obj: *c.GObject, _: *c.GParamSpec, _: c.gpointer) callconv(.c) void {
     if (updating) return;
     const widget: *c.GtkWidget = @ptrCast(obj);
-    const active = c.adw_switch_row_get_active(@as(*c.AdwSwitchRow, @ptrCast(widget))) != 0;
+    const active = c.gtk_switch_get_active(@as(*c.GtkSwitch, @ptrCast(widget))) != 0;
     const cfg = config_mod.getMut();
 
     if (widget == w.desktop_notifications) {
@@ -764,7 +782,7 @@ fn onSpinChanged(obj: *c.GObject, _: *c.GParamSpec, _: c.gpointer) callconv(.c) 
     const cfg = config_mod.getMut();
 
     // AdwSpinRow
-    const val = c.adw_spin_row_get_value(@as(*c.AdwSpinRow, @ptrCast(widget)));
+    const val = c.gtk_spin_button_get_value(@as(*c.GtkSpinButton, @ptrCast(widget)));
 
     if (widget == w.font_size) {
         cfg.font_size = val;
@@ -818,8 +836,8 @@ fn onEntryChanged(obj: *c.GtkEditable, _: c.gpointer) callconv(.c) void {
 
 fn onFontChanged(obj: *c.GObject, _: *c.GParamSpec, _: c.gpointer) callconv(.c) void {
     if (updating) return;
-    const btn: *c.GtkFontDialogButton = @ptrCast(@alignCast(obj));
-    const desc: ?*const c.PangoFontDescription = c.gtk_font_dialog_button_get_font_desc(btn);
+    const btn: *c.GtkFontChooser = @ptrCast(@alignCast(obj));
+    const desc: ?*const c.PangoFontDescription = c.gtk_font_chooser_get_font_desc(btn);
     if (desc) |d| {
         const family: ?[*:0]const u8 = c.pango_font_description_get_family(d);
         if (family) |f| {
@@ -834,7 +852,7 @@ fn onFontChanged(obj: *c.GObject, _: *c.GParamSpec, _: c.gpointer) callconv(.c) 
                 // Update font size spin if present
                 if (w.font_size) |spin| {
                     updating = true;
-                    c.adw_spin_row_set_value(@as(*c.AdwSpinRow, @ptrCast(spin)), pt);
+                    c.gtk_spin_button_set_value(@as(*c.GtkSpinButton, @ptrCast(spin)), pt);
                     updating = false;
                 }
             }
@@ -962,21 +980,22 @@ fn updateShortcutButtonLabel(action: keybinds.Action) void {
 
 fn onResetClicked(_: *c.GtkButton, _: c.gpointer) callconv(.c) void {
     // Show confirmation dialog
-    const dialog = c.adw_alert_dialog_new("Reset all settings to defaults?", "This will restore every setting to its default value. Your config file will be overwritten.");
-    c.adw_alert_dialog_add_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "cancel", "Cancel");
-    c.adw_alert_dialog_add_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "reset", "Reset All");
-    c.adw_alert_dialog_set_response_appearance(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "reset", c.ADW_RESPONSE_DESTRUCTIVE);
-    c.adw_alert_dialog_set_default_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "cancel");
-    c.adw_alert_dialog_set_close_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "cancel");
+    const dialog = c.adw_message_dialog_new(null, "Reset all settings to defaults?", "This will restore every setting to its default value. Your config file will be overwritten.");
+    c.adw_message_dialog_add_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "cancel", "Cancel");
+    c.adw_message_dialog_add_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "reset", "Reset All");
+    c.adw_message_dialog_set_response_appearance(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "reset", c.ADW_RESPONSE_DESTRUCTIVE);
+    c.adw_message_dialog_set_default_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "cancel");
+    c.adw_message_dialog_set_close_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "cancel");
 
     _ = c.g_signal_connect_data(@as(c.gpointer, @ptrCast(dialog)), "response", @as(c.GCallback, @ptrCast(&onResetResponse)), null, null, 0);
 
     if (win) |window| {
-        c.adw_dialog_present(@as(*c.AdwDialog, @ptrCast(dialog)), window);
+        c.gtk_window_set_transient_for(@as(*c.GtkWindow, @ptrCast(dialog)), @as(*c.GtkWindow, @ptrCast(window)));
+        c.gtk_window_present(@as(*c.GtkWindow, @ptrCast(dialog)));
     }
 }
 
-fn onResetResponse(_: *c.AdwAlertDialog, response: [*:0]const u8, _: c.gpointer) callconv(.c) void {
+fn onResetResponse(_: *c.AdwMessageDialog, response: [*:0]const u8, _: c.gpointer) callconv(.c) void {
     if (!std.mem.eql(u8, std.mem.sliceTo(response, 0), "reset")) return;
 
     // Reset config to defaults
@@ -992,7 +1011,7 @@ fn onResetResponse(_: *c.AdwAlertDialog, response: [*:0]const u8, _: c.gpointer)
 
     // Close settings and reopen to refresh all widgets
     if (win) |window| {
-        c.adw_dialog_force_close(@as(*c.AdwDialog, @ptrCast(window)));
+        c.gtk_window_destroy(@as(*c.GtkWindow, @ptrCast(window)));
     }
 }
 
@@ -1106,7 +1125,7 @@ fn onTestNotificationClicked(_: *c.GtkButton, _: c.gpointer) callconv(.c) void {
     state.sound_player.playPreview(cfg.notification_sound);
 }
 
-fn onDialogClosed(_: *c.AdwDialog, _: c.gpointer) callconv(.c) void {
+fn onDialogClosed(_: *c.GtkWidget, _: c.gpointer) callconv(.c) void {
     // Remove key controller from dialog widget (it owns the controller, so this frees it)
     if (key_ctrl_ref) |ctrl| {
         if (dialog_widget_ref) |dw| {

--- a/src/shortcuts_overlay.zig
+++ b/src/shortcuts_overlay.zig
@@ -140,18 +140,19 @@ pub fn show(wm: *WindowManager) void {
     const parent = if (wm.active_window) |active| active.gtk_window else null;
     if (parent == null) return;
 
-    const win = c.adw_dialog_new();
-    c.adw_dialog_set_title(@as(*c.AdwDialog, @ptrCast(win)), "Keyboard Shortcuts");
-    c.adw_dialog_set_content_width(@as(*c.AdwDialog, @ptrCast(win)), 900);
-    c.adw_dialog_set_content_height(@as(*c.AdwDialog, @ptrCast(win)), 600);
+    // libadwaita 1.2 compat: AdwDialog (1.5) -> AdwWindow (a GtkWindow).
+    const win = c.adw_window_new();
+    c.gtk_window_set_title(@as(*c.GtkWindow, @ptrCast(win)), "Keyboard Shortcuts");
+    c.gtk_window_set_default_size(@as(*c.GtkWindow, @ptrCast(win)), 900, 600);
+    c.gtk_window_set_transient_for(@as(*c.GtkWindow, @ptrCast(win)), @ptrCast(@alignCast(parent.?)));
+    c.gtk_window_set_modal(@as(*c.GtkWindow, @ptrCast(win)), 1);
 
     // Header bar
     const header = c.adw_header_bar_new();
 
-    // Toolbar view (flat top bar)
-    const toolbar_view = c.adw_toolbar_view_new();
-    c.adw_toolbar_view_add_top_bar(@as(*c.AdwToolbarView, @ptrCast(toolbar_view)), @ptrCast(header));
-    c.adw_toolbar_view_set_top_bar_style(@as(*c.AdwToolbarView, @ptrCast(toolbar_view)), c.ADW_TOOLBAR_FLAT);
+    // libadwaita 1.2 compat: AdwToolbarView (1.4) -> vertical GtkBox.
+    const toolbar_view = c.gtk_box_new(c.GTK_ORIENTATION_VERTICAL, 0);
+    c.gtk_box_append(@ptrCast(toolbar_view), @ptrCast(header));
 
     // Two-column layout inside a scrolled window
     const scroll = c.gtk_scrolled_window_new();
@@ -181,13 +182,15 @@ pub fn show(wm: *WindowManager) void {
     c.gtk_box_append(@ptrCast(hbox), right_col);
     c.gtk_scrolled_window_set_child(@ptrCast(scroll), hbox);
 
-    c.adw_toolbar_view_set_content(@as(*c.AdwToolbarView, @ptrCast(toolbar_view)), scroll);
-    c.adw_dialog_set_child(@as(*c.AdwDialog, @ptrCast(win)), @ptrCast(toolbar_view));
+    c.gtk_widget_set_vexpand(scroll, 1);
+    c.gtk_box_append(@ptrCast(toolbar_view), scroll);
+    c.adw_window_set_content(@as(*c.AdwWindow, @ptrCast(win)), @ptrCast(toolbar_view));
 
-    // Closed signal — reset singleton
+    // Destroy signal — reset singleton (fires on user close too, since
+    // GtkWindow:hide-on-close defaults to false).
     _ = c.g_signal_connect_data(
         @as(c.gpointer, @ptrCast(win)),
-        "closed",
+        "destroy",
         @as(c.GCallback, @ptrCast(&onDialogClosed)),
         null,
         null,
@@ -195,7 +198,7 @@ pub fn show(wm: *WindowManager) void {
     );
 
     dialog = @as(*c.GtkWidget, @ptrCast(win));
-    c.adw_dialog_present(@as(*c.AdwDialog, @ptrCast(win)), parent.?);
+    c.gtk_window_present(@as(*c.GtkWindow, @ptrCast(win)));
 }
 
 // ---------------------------------------------------------------------------
@@ -279,6 +282,6 @@ fn addRangeRow(list: *c.GtkWidget, range: RangeEntry) void {
     c.gtk_list_box_append(@ptrCast(list), row);
 }
 
-fn onDialogClosed(_: *c.AdwDialog, _: c.gpointer) callconv(.c) void {
+fn onDialogClosed(_: *c.GtkWidget, _: c.gpointer) callconv(.c) void {
     dialog = null;
 }

--- a/src/vertical_tab_bar.zig
+++ b/src/vertical_tab_bar.zig
@@ -329,10 +329,10 @@ pub const VerticalTabBar = struct {
             const css = std.fmt.bufPrintZ(&css_buf, ".vtab-color-bar {{ background-color: {s}; }}", .{hex}) catch return;
 
             if (tab.color_bar_provider) |provider| {
-                c.gtk_css_provider_load_from_string(provider, css.ptr);
+                c.gtk_css_provider_load_from_data(provider, css.ptr, -1);
             } else {
                 const provider = c.gtk_css_provider_new();
-                c.gtk_css_provider_load_from_string(provider, css.ptr);
+                c.gtk_css_provider_load_from_data(provider, css.ptr, -1);
                 const ctx = c.gtk_widget_get_style_context(tab.color_bar);
                 c.gtk_style_context_add_provider(ctx, @ptrCast(provider), c.GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
                 tab.color_bar_provider = provider;

--- a/src/window.zig
+++ b/src/window.zig
@@ -94,7 +94,9 @@ pub const WindowState = struct {
     port_scan_timer: c.guint = 0,
     command_palette: command_palette_mod.CommandPalette = undefined,
     toast_overlay: *c.GtkWidget = undefined,
-    banner: ?*c.GtkWidget = null,
+    banner: ?*c.GtkWidget = null, // GtkRevealer (1.2-compat replacement for AdwBanner)
+    banner_label: ?*c.GtkWidget = null, // GtkLabel inside the banner
+    banner_button: ?*c.GtkWidget = null, // optional action button inside the banner
     banner_is_config_error: bool = false,
     metadata_in_flight: bool = false,
     port_scan_in_flight: bool = false,
@@ -766,13 +768,13 @@ pub const WindowState = struct {
     pub fn renameWorkspace(self: *WindowState) void {
         const ws = self.activeWorkspace() orelse return;
 
-        const dialog = c.adw_alert_dialog_new("Rename Workspace", null);
-        c.adw_alert_dialog_add_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "cancel", "Cancel");
-        c.adw_alert_dialog_add_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "clear", "Clear");
-        c.adw_alert_dialog_add_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "rename", "Rename");
-        c.adw_alert_dialog_set_response_appearance(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "rename", c.ADW_RESPONSE_SUGGESTED);
-        c.adw_alert_dialog_set_default_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "rename");
-        c.adw_alert_dialog_set_close_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "cancel");
+        const dialog = c.adw_message_dialog_new(@ptrCast(@alignCast(self.gtk_window)), "Rename Workspace", null);
+        c.adw_message_dialog_add_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "cancel", "Cancel");
+        c.adw_message_dialog_add_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "clear", "Clear");
+        c.adw_message_dialog_add_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "rename", "Rename");
+        c.adw_message_dialog_set_response_appearance(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "rename", c.ADW_RESPONSE_SUGGESTED);
+        c.adw_message_dialog_set_default_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "rename");
+        c.adw_message_dialog_set_close_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "cancel");
 
         const entry = c.gtk_entry_new();
         c.gtk_entry_set_activates_default(@ptrCast(entry), 1);
@@ -782,7 +784,7 @@ pub const WindowState = struct {
         @memcpy(title_z[0..tlen], ws_title[0..tlen]);
         title_z[tlen] = 0;
         c.gtk_editable_set_text(@ptrCast(entry), &title_z);
-        c.adw_alert_dialog_set_extra_child(@as(*c.AdwAlertDialog, @ptrCast(dialog)), entry);
+        c.adw_message_dialog_set_extra_child(@as(*c.AdwMessageDialog, @ptrCast(dialog)), entry);
 
         const ctx = self.alloc.create(RenameDialogCtx) catch return;
         ctx.* = .{
@@ -792,7 +794,7 @@ pub const WindowState = struct {
         };
 
         _ = c.g_signal_connect_data(@as(c.gpointer, @ptrCast(dialog)), "response", @as(c.GCallback, @ptrCast(&onRenameResponse)), @ptrCast(ctx), null, 0);
-        c.adw_dialog_present(@as(*c.AdwDialog, @ptrCast(dialog)), self.gtk_window);
+        c.gtk_window_present(@ptrCast(@alignCast(dialog)));
 
         _ = c.gtk_widget_grab_focus(entry);
         c.gtk_editable_select_region(@ptrCast(entry), 0, -1);
@@ -828,13 +830,13 @@ pub const WindowState = struct {
         const group = ws.focusedGroup() orelse return;
         const pane = group.focusedTerminalPane() orelse return;
 
-        const dialog = c.adw_alert_dialog_new("Rename Tab", null);
-        c.adw_alert_dialog_add_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "cancel", "Cancel");
-        c.adw_alert_dialog_add_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "clear", "Clear");
-        c.adw_alert_dialog_add_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "rename", "Rename");
-        c.adw_alert_dialog_set_response_appearance(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "rename", c.ADW_RESPONSE_SUGGESTED);
-        c.adw_alert_dialog_set_default_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "rename");
-        c.adw_alert_dialog_set_close_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "cancel");
+        const dialog = c.adw_message_dialog_new(@ptrCast(@alignCast(self.gtk_window)), "Rename Tab", null);
+        c.adw_message_dialog_add_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "cancel", "Cancel");
+        c.adw_message_dialog_add_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "clear", "Clear");
+        c.adw_message_dialog_add_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "rename", "Rename");
+        c.adw_message_dialog_set_response_appearance(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "rename", c.ADW_RESPONSE_SUGGESTED);
+        c.adw_message_dialog_set_default_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "rename");
+        c.adw_message_dialog_set_close_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "cancel");
 
         const entry = c.gtk_entry_new();
         c.gtk_entry_set_activates_default(@ptrCast(entry), 1);
@@ -844,7 +846,7 @@ pub const WindowState = struct {
         @memcpy(title_z[0..tlen], display_title[0..tlen]);
         title_z[tlen] = 0;
         c.gtk_editable_set_text(@ptrCast(entry), &title_z);
-        c.adw_alert_dialog_set_extra_child(@as(*c.AdwAlertDialog, @ptrCast(dialog)), entry);
+        c.adw_message_dialog_set_extra_child(@as(*c.AdwMessageDialog, @ptrCast(dialog)), entry);
 
         const ctx = self.alloc.create(RenameTabDialogCtx) catch return;
         ctx.* = .{
@@ -854,7 +856,7 @@ pub const WindowState = struct {
         };
 
         _ = c.g_signal_connect_data(@as(c.gpointer, @ptrCast(dialog)), "response", @as(c.GCallback, @ptrCast(&onRenameTabResponse)), @ptrCast(ctx), null, 0);
-        c.adw_dialog_present(@as(*c.AdwDialog, @ptrCast(dialog)), self.gtk_window);
+        c.gtk_window_present(@ptrCast(@alignCast(dialog)));
 
         _ = c.gtk_widget_grab_focus(entry);
         c.gtk_editable_select_region(@ptrCast(entry), 0, -1);
@@ -1076,19 +1078,22 @@ pub const WindowState = struct {
 
     pub fn showBanner(self: *WindowState, message: [*:0]const u8, is_config_error: bool) void {
         const banner = self.banner orelse return;
-        c.adw_banner_set_title(@ptrCast(banner), message);
-        if (is_config_error) {
-            c.adw_banner_set_button_label(@ptrCast(banner), "Open Settings");
-        } else {
-            c.adw_banner_set_button_label(@ptrCast(banner), null);
+        if (self.banner_label) |label| c.gtk_label_set_text(@ptrCast(label), message);
+        if (self.banner_button) |btn| {
+            if (is_config_error) {
+                c.gtk_button_set_label(@ptrCast(btn), "Open Settings");
+                c.gtk_widget_set_visible(btn, 1);
+            } else {
+                c.gtk_widget_set_visible(btn, 0);
+            }
         }
         self.banner_is_config_error = is_config_error;
-        c.adw_banner_set_revealed(@ptrCast(banner), 1);
+        c.gtk_revealer_set_reveal_child(@ptrCast(banner), 1);
     }
 
     pub fn hideBanner(self: *WindowState) void {
         const banner = self.banner orelse return;
-        c.adw_banner_set_revealed(@ptrCast(banner), 0);
+        c.gtk_revealer_set_reveal_child(@ptrCast(banner), 0);
     }
 
     pub fn showOpenFolderDialog(self: *WindowState) void {
@@ -1182,10 +1187,12 @@ pub const WindowState = struct {
         _ = c.g_signal_connect_data(@ptrCast(hide_btn), "clicked", @ptrCast(&sidebar_mod.onSidebarHideClicked), @ptrCast(sidebar_ptr), null, 0);
         _ = c.g_signal_connect_data(@ptrCast(settings_btn), "clicked", @ptrCast(&sidebar_mod.onSettingsClicked), @ptrCast(sidebar_ptr), null, 0);
 
-        const toolbar_view = c.adw_toolbar_view_new();
-        c.adw_toolbar_view_add_top_bar(@as(*c.AdwToolbarView, @ptrCast(toolbar_view)), @ptrCast(header));
-        c.adw_toolbar_view_set_top_bar_style(@as(*c.AdwToolbarView, @ptrCast(toolbar_view)), c.ADW_TOOLBAR_FLAT);
-        c.adw_toolbar_view_set_content(@as(*c.AdwToolbarView, @ptrCast(toolbar_view)), self.banner_box);
+        // GTK 4.8 / libadwaita 1.2 compat: AdwToolbarView (1.4) is unavailable;
+        // a vertical GtkBox (header on top, content below) is the equivalent.
+        const toolbar_view = c.gtk_box_new(c.GTK_ORIENTATION_VERTICAL, 0);
+        c.gtk_box_append(@ptrCast(toolbar_view), @ptrCast(header));
+        c.gtk_widget_set_vexpand(self.banner_box, 1);
+        c.gtk_box_append(@ptrCast(toolbar_view), self.banner_box);
         c.adw_application_window_set_content(@ptrCast(window), toolbar_view);
 
         self.toolbar_view = @ptrCast(toolbar_view);
@@ -1258,7 +1265,7 @@ pub const WindowState = struct {
                 if (self.toolbar_view) |tv| {
                     // Detach banner_box from the toolbar_view first so it
                     // isn't destroyed along with it.
-                    c.adw_toolbar_view_set_content(@as(*c.AdwToolbarView, @ptrCast(tv)), null);
+                    c.gtk_box_remove(@ptrCast(tv), self.banner_box);
                 }
                 c.adw_application_window_set_content(@ptrCast(self.gtk_window), null);
                 self.toolbar_view = null;
@@ -1447,14 +1454,39 @@ pub fn create(wm: *WindowManager) !*WindowState {
     c.adw_toast_overlay_set_child(@ptrCast(toast_overlay), window_overlay);
     state.toast_overlay = toast_overlay;
 
-    // Error banner (hidden by default, revealed on config/session errors)
-    const banner = c.adw_banner_new("");
-    c.adw_banner_set_revealed(@ptrCast(banner), 0);
+    // Error banner (hidden by default, revealed on config/session errors).
+    // GTK 4.8 / libadwaita 1.2 compat: AdwBanner (1.4) is unavailable, so build
+    // an equivalent from a GtkRevealer wrapping a label + optional action button.
+    const banner = c.gtk_revealer_new();
+    c.gtk_revealer_set_transition_type(@ptrCast(banner), c.GTK_REVEALER_TRANSITION_TYPE_SLIDE_DOWN);
+    c.gtk_revealer_set_reveal_child(@ptrCast(banner), 0);
+
+    const banner_inner = c.gtk_box_new(c.GTK_ORIENTATION_HORIZONTAL, 6);
+    c.gtk_widget_add_css_class(banner_inner, "app-notification");
+    c.gtk_widget_set_margin_start(banner_inner, 12);
+    c.gtk_widget_set_margin_end(banner_inner, 12);
+    c.gtk_widget_set_margin_top(banner_inner, 6);
+    c.gtk_widget_set_margin_bottom(banner_inner, 6);
+
+    const banner_label = c.gtk_label_new("");
+    c.gtk_widget_set_hexpand(banner_label, 1);
+    c.gtk_label_set_xalign(@ptrCast(banner_label), 0);
+    c.gtk_label_set_wrap(@ptrCast(banner_label), 1);
+    c.gtk_box_append(@ptrCast(banner_inner), banner_label);
+
+    const banner_button = c.gtk_button_new_with_label("");
+    c.gtk_widget_set_valign(banner_button, c.GTK_ALIGN_CENTER);
+    c.gtk_widget_set_visible(banner_button, 0);
+    c.gtk_box_append(@ptrCast(banner_inner), banner_button);
+
+    c.gtk_revealer_set_child(@ptrCast(banner), banner_inner);
     state.banner = @ptrCast(banner);
+    state.banner_label = @ptrCast(banner_label);
+    state.banner_button = @ptrCast(banner_button);
 
     _ = c.g_signal_connect_data(
-        @as(c.gpointer, @ptrCast(banner)),
-        "button-clicked",
+        @as(c.gpointer, @ptrCast(banner_button)),
+        "clicked",
         @as(c.GCallback, @ptrCast(&onBannerButtonClicked)),
         @as(c.gpointer, @ptrCast(state)),
         null,
@@ -1618,18 +1650,18 @@ fn showCloseConfirmation(state: *WindowState) void {
     const title: [*:0]const u8 = if (is_last) "Quit Seance?" else "Close window?";
     const confirm_label: [*:0]const u8 = if (is_last) "Quit" else "Close Window";
 
-    const dialog = c.adw_alert_dialog_new(title, &msg_buf);
-    c.adw_alert_dialog_add_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "cancel", "Cancel");
-    c.adw_alert_dialog_add_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "close", confirm_label);
-    c.adw_alert_dialog_set_response_appearance(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "close", c.ADW_RESPONSE_DESTRUCTIVE);
-    c.adw_alert_dialog_set_default_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "cancel");
-    c.adw_alert_dialog_set_close_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "cancel");
+    const dialog = c.adw_message_dialog_new(@ptrCast(@alignCast(state.gtk_window)), title, &msg_buf);
+    c.adw_message_dialog_add_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "cancel", "Cancel");
+    c.adw_message_dialog_add_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "close", confirm_label);
+    c.adw_message_dialog_set_response_appearance(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "close", c.ADW_RESPONSE_DESTRUCTIVE);
+    c.adw_message_dialog_set_default_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "cancel");
+    c.adw_message_dialog_set_close_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "cancel");
 
     _ = c.g_signal_connect_data(@as(c.gpointer, @ptrCast(dialog)), "response", @as(c.GCallback, @ptrCast(&onCloseWindowResponse)), @ptrCast(state), null, 0);
-    c.adw_dialog_present(@as(*c.AdwDialog, @ptrCast(dialog)), state.gtk_window);
+    c.gtk_window_present(@ptrCast(@alignCast(dialog)));
 }
 
-fn onCloseWindowResponse(_: *c.AdwAlertDialog, response: [*:0]const u8, data: c.gpointer) callconv(.c) void {
+fn onCloseWindowResponse(_: *c.AdwMessageDialog, response: [*:0]const u8, data: c.gpointer) callconv(.c) void {
     if (!std.mem.eql(u8, std.mem.sliceTo(response, 0), "close")) return;
     const state: *WindowState = @ptrCast(@alignCast(data));
     state.window_manager.closeWindow(state);
@@ -1662,18 +1694,18 @@ fn showQuitConfirmation(state: *WindowState) void {
         _ = std.fmt.bufPrint(&msg_buf, "{d} workspaces will be saved and restored next launch.", .{ws_total}) catch {};
     }
 
-    const dialog = c.adw_alert_dialog_new("Quit Seance?", &msg_buf);
-    c.adw_alert_dialog_add_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "cancel", "Cancel");
-    c.adw_alert_dialog_add_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "quit", "Quit");
-    c.adw_alert_dialog_set_response_appearance(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "quit", c.ADW_RESPONSE_DESTRUCTIVE);
-    c.adw_alert_dialog_set_default_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "cancel");
-    c.adw_alert_dialog_set_close_response(@as(*c.AdwAlertDialog, @ptrCast(dialog)), "cancel");
+    const dialog = c.adw_message_dialog_new(@ptrCast(@alignCast(state.gtk_window)), "Quit Seance?", &msg_buf);
+    c.adw_message_dialog_add_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "cancel", "Cancel");
+    c.adw_message_dialog_add_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "quit", "Quit");
+    c.adw_message_dialog_set_response_appearance(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "quit", c.ADW_RESPONSE_DESTRUCTIVE);
+    c.adw_message_dialog_set_default_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "cancel");
+    c.adw_message_dialog_set_close_response(@as(*c.AdwMessageDialog, @ptrCast(dialog)), "cancel");
 
     _ = c.g_signal_connect_data(@as(c.gpointer, @ptrCast(dialog)), "response", @as(c.GCallback, @ptrCast(&onQuitResponse)), @ptrCast(state), null, 0);
-    c.adw_dialog_present(@as(*c.AdwDialog, @ptrCast(dialog)), state.gtk_window);
+    c.gtk_window_present(@ptrCast(@alignCast(dialog)));
 }
 
-fn onQuitResponse(_: *c.AdwAlertDialog, response: [*:0]const u8, data: c.gpointer) callconv(.c) void {
+fn onQuitResponse(_: *c.AdwMessageDialog, response: [*:0]const u8, data: c.gpointer) callconv(.c) void {
     if (!std.mem.eql(u8, std.mem.sliceTo(response, 0), "quit")) return;
     const state: *WindowState = @ptrCast(@alignCast(data));
     triggerQuit(state.window_manager);
@@ -2008,7 +2040,7 @@ const RenameDialogCtx = struct {
     entry: *c.GtkEditable,
 };
 
-fn onRenameResponse(_: *c.AdwAlertDialog, response: [*:0]const u8, data: c.gpointer) callconv(.c) void {
+fn onRenameResponse(_: *c.AdwMessageDialog, response: [*:0]const u8, data: c.gpointer) callconv(.c) void {
     const ctx: *RenameDialogCtx = @ptrCast(@alignCast(data));
     const resp = std.mem.sliceTo(response, 0);
 
@@ -2048,7 +2080,7 @@ const RenameTabDialogCtx = struct {
     entry: *c.GtkEditable,
 };
 
-fn onRenameTabResponse(_: *c.AdwAlertDialog, response: [*:0]const u8, data: c.gpointer) callconv(.c) void {
+fn onRenameTabResponse(_: *c.AdwMessageDialog, response: [*:0]const u8, data: c.gpointer) callconv(.c) void {
     const ctx: *RenameTabDialogCtx = @ptrCast(@alignCast(data));
     const resp = std.mem.sliceTo(response, 0);
 
@@ -2309,10 +2341,10 @@ fn loadThemeCss() void {
     css_buf[pos] = 0;
 
     if (css_provider_global) |provider| {
-        c.gtk_css_provider_load_from_string(provider, @ptrCast(&css_buf));
+        c.gtk_css_provider_load_from_data(provider, @ptrCast(&css_buf), -1);
     } else {
         const provider = c.gtk_css_provider_new();
-        c.gtk_css_provider_load_from_string(provider, @ptrCast(&css_buf));
+        c.gtk_css_provider_load_from_data(provider, @ptrCast(&css_buf), -1);
         c.gtk_style_context_add_provider_for_display(
             c.gdk_display_get_default(),
             @ptrCast(provider),


### PR DESCRIPTION
## What

Adds a compatibility layer so séance builds and runs on **Debian 12 "bookworm"**, which ships **GTK 4.8.3** and **libadwaita 1.2.2** — older than séance's current target (GTK 4.12+, libadwaita 1.4/1.5+). Useful for Debian 12 and other LTS distros that haven't moved to libadwaita 1.4+ yet. Tested on **arm64 (aarch64)**; the substitutions apply equally to amd64.

## Why

A clean `zig build` on Debian 12 fails with ~50 missing-symbol errors across the UI code, because several GTK/libadwaita calls don't exist in the older libraries.

## How

Each newer API is replaced with a behaviourally equivalent one that already exists in GTK 4.8 / libadwaita 1.2 (source-level only, **no new runtime dependencies**):

| Upstream API (min version) | Debian 12 replacement |
| --- | --- |
| `gtk_gl_area_set_allowed_apis` (GTK 4.12) | `gtk_gl_area_set_use_es(area, FALSE)` — keeps the desktop-GL request |
| `gtk_css_provider_load_from_string` (GTK 4.12) | `gtk_css_provider_load_from_data(p, data, -1)` |
| `gtk_search_entry_set_placeholder_text` (GTK 4.10) | placeholder set on the entry's `GtkText` editable delegate |
| `GtkFontDialogButton` (GTK 4.10) | `GtkFontButton` (via `GtkFontChooser` `font-desc`) |
| `AdwAlertDialog` (libadwaita 1.5) | `AdwMessageDialog` (1.2) |
| `AdwDialog` (libadwaita 1.5) | `AdwWindow` + `GtkWindow` (modal, transient-for, present) |
| `AdwToolbarView` (libadwaita 1.4) | vertical `GtkBox` (header on top, content below) |
| `AdwBanner` (libadwaita 1.4) | `GtkRevealer` + label + optional action button |
| `AdwSpinRow` (libadwaita 1.4) | `AdwActionRow` + `GtkSpinButton` |
| `AdwSwitchRow` (libadwaita 1.4) | `AdwActionRow` + `GtkSwitch` |
| `adw_combo_row_set_enable_search` (libadwaita 1.4) | omitted (search box is optional) |

Also adds `packaging/debian12/`:
- `install.sh` — installs build deps, fetches Zig 0.15.2 (not packaged in Debian 12), builds, installs.
- `README.md` — documents the substitutions, dependencies, and the GPU note below.

## Testing

On Debian 12 arm64:
- ✅ Builds cleanly from source (libghostty + séance).
- ✅ Launches and stays running; `seance ctl ping` → `pong`; `seance ctl tree` / `identify` work.
- ✅ OpenGL context creation succeeds.

**Caveats / help wanted:**
- My test box is a VM with `virtio-gpu` and **no accelerated GL**, so I had to force Mesa's software renderer (`LIBGL_ALWAYS_SOFTWARE=1`) to get a GL context. The `gtk_gl_area_set_use_es(FALSE)` substitution preserves the original desktop-GL request, but I'd appreciate confirmation on hardware-GL arm64.
- Because the panes only initialise once the compositor maps/paints the window, I couldn't fully exercise **interactive terminal rendering** in my headless session — would value a sanity check on a real desktop.
- There's a non-fatal `Adwaita-CRITICAL ... adw_tab_view_close_page: assertion 'page_belongs_to_this_view' failed` logged once at startup. It doesn't appear related to these substitutions (it's in tab-view setup), but flagging it in case it's meaningful.

Happy to adjust the approach (e.g. gate the older paths behind a libadwaita-version check / build option) if you'd prefer to keep the modern APIs as the default.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
